### PR TITLE
Fix application check and add test

### DIFF
--- a/applications/tests.py
+++ b/applications/tests.py
@@ -1,3 +1,29 @@
 from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
 
-# Create your tests here.
+from .models import Applicant, Application, RecruitmentSettings
+
+
+class IndexViewTests(TestCase):
+    def setUp(self):
+        now = timezone.now()
+        self.recruitment = RecruitmentSettings.objects.create(
+            application_start_date=now - timezone.timedelta(days=1),
+            application_end_date=now + timezone.timedelta(days=1),
+            interview_start_date=now,
+            interview_end_date=now,
+            recruitment_notice="",
+        )
+        self.applicant = Applicant.objects.create_user(
+            email="test@example.com", password="test", name="Test"
+        )
+        Application.objects.create(
+            applicant=self.applicant, recruitment_settings=self.recruitment
+        )
+
+    def test_has_application_context_true_when_application_exists(self):
+        self.client.login(username="test@example.com", password="test")
+        response = self.client.get(reverse("applications:index"))
+        self.assertTrue(response.context["has_application"])
+

--- a/applications/views.py
+++ b/applications/views.py
@@ -32,7 +32,7 @@ def index(request):
     }
     
     if request.user.is_authenticated:
-        context['has_application'] = hasattr(request.user, 'application_set') and request.user.application_set.exists()
+        context['has_application'] = request.user.applications.exists()
     
     return render(request, 'applications/index.html', context)
 
@@ -44,7 +44,7 @@ def start_application(request):
     # 이미 로그인한 사용자의 경우
     if request.user.is_authenticated:
         # 지원서가 있는 경우 질문 답변 페이지로 리다이렉트
-        if hasattr(request.user, 'applications') and request.user.applications.filter(recruitment_settings=recruitment).exists():
+        if request.user.applications.filter(recruitment_settings=recruitment).exists():
             return redirect('applications:answer_questions')
         
         # 지원서가 없는 경우 기존 정보로 폼 초기화


### PR DESCRIPTION
## Summary
- fix `index` view to use `request.user.applications` relation
- drop unnecessary `hasattr` guard in `start_application`
- add regression test for `has_application` context

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6841885199748327967dcd155aaa549d